### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Code of Merit
 
-## A meritocratic code of conduct devoid of social politics.
+## A meritocratic code of conduct for software projects.
 
-This Code of Merit should not be necessary. The fact that it is necessary means there is something wrong with the solutions the software industry is trying. They should recognize that fact and not insist that their solution is the only solution.
+This Code should not be necessary. The fact that it is necessary means there is something wrong with the solutions the software industry is trying. They should recognize that fact and not insist that their solution is the only solution.
 
 1. Software is like nature: it evolves, so the best implementation must prevail.
 2. You will contribute, you will learn, and mistakes are allowed.
@@ -11,9 +11,9 @@ This Code of Merit should not be necessary. The fact that it is necessary means 
 5. Harassment as defined by law will not be allowed. Questioning is not harassment. Repeated questioning after an individual has stated their desire for disengagement is harassment.
 6. Censorship will not be permitted. Seeking to silence an individual voicing constructive opinions will not be allowed. Silencing vitriol is not censorship.
 7. This is a space for technical prowess; world politics have no place here.
-8. Everything that makes a person an individual, including but not limited to body, sex, sexual preference, race, language, religion, nationality, or political preferences are irrelevant in the scope of a technical project.
+8. Everything that makes a person an individual, including but not limited to body, sex, sexual preference, gender, gender identity, race, language, religion, nationality, or political preferences are irrelevant in the scope of a technical project.
 9. Everybody is different, so differences will not be mentioned by anyone, even by the individual suffering/experiencing/having/enjoying them. We are all individuals seeking the common goal of improving ourselves and improving our collective project.
 10. Everybody has the same rights and the same opportunities to seek any challenge they want. The chance to screw up will not be denied to anybody.
 11. There is no room for ambiguity: if an individual is ambiguous regarding a statement it is up to the individual to provide more context. Ambiguity will be met with questioning; further ambiguity will be met with silence.
 12. If a discussion arises that cannot be solved in the space of the project, it will be discussed in a separate space. Disruption of the project will not be allowed.
-13. This Code of Merit does not take precedence over governing law.
+13. This Code does not take precedence over governing law.


### PR DESCRIPTION
1. Would drop "devoid of social politics". Choosing to regulate conduct based on merit rather than on social justice/identity politics/feelings is a political choice'. Admittedly it's the only choice, but it's a crucial one.
Add "for software projects" to clarify the scope of the code for outside readers and for journalists who'd like to cover the code and the meta-discussion.

2. Remove "Merit" in the body of the text for simplicity and ease of localization. Merit in the English meaning doesn't have a perfectly matching translation in my languages (FR and PL). I want to avoid clunky approximations (already raised re my first Polish versions).
Also, the practice in legal texts is to refer to the Code, the Bill, the Draft rather than to the full or partial title.

3. gender/gender identity: clarifying sex as the biological reality and gender as the psychological experience reflects a currently popular discussion .