### PR TITLE
Semantic Line Breaks, +more

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,50 @@
 
 ## A meritocratic code of conduct devoid of social politics.
 
-This Code of Merit should not be necessary. The fact that it is necessary means there is something wrong with the solutions the software industry is trying. They should recognize that fact and not insist that their solution is the only solution.
+This Code of Merit should not be necessary.
+The fact that it is necessary means that
+there is something wrong with the current
+solutions in use in the software industry.
 
-1. Software is like nature: it evolves, so the best implementation must prevail.
-2. You will contribute, you will learn, and mistakes are allowed.
-3. Mistakes are not final and everybody has a second chance.
-4. Don't expect others to do your work or help you with your work forever. 
-5. Harassment as defined by law will not be allowed. Questioning is not harassment. Repeated questioning after an individual has stated their desire for disengagement is harassment.
-6. Censorship will not be permitted. Seeking to silence an individual voicing constructive opinions will not be allowed. Silencing vitriol is not censorship.
-7. This is a space for technical prowess; world politics have no place here.
-8. Everything that makes a person an individual, including but not limited to body, sex, sexual preference, race, language, religion, nationality, or political preferences are irrelevant in the scope of a technical project.
-9. Everybody is different, so differences will not be mentioned by anyone, even by the individual suffering/experiencing/having/enjoying them. We are all individuals seeking the common goal of improving ourselves and improving our collective project.
-10. Everybody has the same rights and the same opportunities to seek any challenge they want. The chance to screw up will not be denied to anybody.
-11. There is no room for ambiguity: if an individual is ambiguous regarding a statement it is up to the individual to provide more context. Ambiguity will be met with questioning; further ambiguity will be met with silence.
-12. If a discussion arises that cannot be solved in the space of the project, it will be discussed in a separate space. Disruption of the project will not be allowed.
-13. This Code of Merit does not take precedence over governing law.
+1. Software is like nature: it evolves,
+and so the best implementation must prevail.
+2. You will contribute, you will learn,
+and mistakes are allowed.
+3. Mistakes are not final and everybody
+has a second chance.
+4. Don't expect others to do your work or
+help you with your work. 
+5. Harassment as defined by law will is not
+allowed. Questioning is not harassment. 
+Repeated questioning after an individual has
+stated their desire for disengagement is harassment.
+6. Censorship will not be permitted. 
+Seeking to silence an individual voicing
+constructive opinions will not be allowed.
+Silencing vitriol is not censorship.
+7. This is a space for technical prowess;
+politics have no place here.
+8. Everything that makes a person an individual,
+including but not limited to body, sex,
+sexual preference, race, language, religion,
+nationality, and political preference are
+irrelevant in the scope of a technical project.
+9. Everybody is different, so differences will
+not be mentioned by anyone, even by the individual
+suffering/experiencing/having/enjoying them.
+We are all individuals seeking the common goal 
+of improving ourselves and improving our collective project.
+10. Everybody has the same rights and the same
+opportunities to seek any challenge they want. The
+chance to screw up will not be denied to anybody.
+11. There is no room for ambiguity: if an
+individual is ambiguous regarding a statement it
+is up to the individual to provide more context.
+Ambiguity will be met with questioning; further
+ambiguity will be met with silence.
+12. If a discussion arises that cannot be solved
+in the space of the project, it will be discussed
+in a separate space. Disruption of the project
+will not be allowed.
+13. This Code of Merit does not take precedence
+over governing law.


### PR DESCRIPTION
Reworded the opening paragraph of the CoM. Use of 'they'
was ambiguous, and the plurality of 'solutions' did not match
the verb 'is'.
Also removed the 'forever' from statement 4. Adding 'forever'
makes it seem as though one may expect others to do work
for him in the short term.
Removed 'world' from statement 7. Politics in general should not
be part of a technical discussion, not just world politics.